### PR TITLE
Fixed pip installation on 4.5.3 LTS

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -749,7 +749,7 @@ class InstallDependencies(bpy.types.Operator):
         try:
             subprocess.check_call([python_exe, "-m", "ensurepip"])
             subprocess.check_call([
-                python_exe, "-m", "pip", "install", "--no-deps", 
+                python_exe, "-m", "pip", "install", "--no-deps", "--upgrade",
                 *missing_deps, "--target", libs_path
             ])
             self.report({'INFO'}, "Installation successful! Please restart Blender.")


### PR DESCRIPTION
On blender 4.5.3 LTS the dependencies fail to install.
After investigating I found that pip could not overwrite existing folders and so the install fails.
Adding `--upgrade` fixes it.

<img width="264" height="113" alt="blender robus weight transfer screenshot" src="https://github.com/user-attachments/assets/849fa615-f603-4898-933d-6889cd8e11f8" />
