### PR TITLE
Add Isolate Loose Parts toggle to prevent weight bleed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -63,7 +63,7 @@ print(missing_deps)
 
 if not missing_deps:
     import igl
-    from .weighttransfer import find_matches_closest_surface, inpaint, limit_mask, smooth_weigths
+    from .weighttransfer import find_matches_closest_surface, inpaint, inpaint_per_island, limit_mask, smooth_weigths
     from . import util
 
 
@@ -148,7 +148,10 @@ class RobustWeightTransfer(bpy.types.Operator):
                     return {'CANCELLED'}
 
                 
-            result, weights = inpaint(verts, triangles, weights, matched_verts, scene_settings.inpaint_mode == 'POINT')
+            if scene_settings.isolate_loose_parts:
+                result, weights = inpaint_per_island(verts, triangles, weights, matched_verts, scene_settings.inpaint_mode == 'POINT')
+            else:
+                result, weights = inpaint(verts, triangles, weights, matched_verts, scene_settings.inpaint_mode == 'POINT')
             if not result:
                 self.report({'ERROR'}, f'Failed weight inpainting on {obj.name}: This usually happens on loose parts, where vertices are not finding a match on the source mesh. Use Select Rejected Loose Parts to solve the issue.')
                 return {'CANCELLED'}
@@ -315,7 +318,10 @@ class Inpaint(bpy.types.Operator):
 
         inpaint_mask = util.get_group_arr(obj, object_settings.inpaint_group)
         inpaint_mask_bin = inpaint_mask > object_settings.inpaint_threshold
-        result, weights = inpaint(verts, triangles, weights, ~inpaint_mask_bin, scene_settings.inpaint_mode == 'POINT')
+        if scene_settings.isolate_loose_parts:
+            result, weights = inpaint_per_island(verts, triangles, weights, ~inpaint_mask_bin, scene_settings.inpaint_mode == 'POINT')
+        else:
+            result, weights = inpaint(verts, triangles, weights, ~inpaint_mask_bin, scene_settings.inpaint_mode == 'POINT')
         if not result:
             self.report({'ERROR'}, f'Failed weight inpainting on {obj.name}: This usually happens on loose parts, where vertices are not finding a match on the source mesh. Use Select Rejected Loose Parts to solve the issue.')
             return {'CANCELLED'}
@@ -425,6 +431,10 @@ class SceneSettingsGroup(bpy.types.PropertyGroup):
     smoothing_enable: bpy.props.BoolProperty(
         name='Enable Smoothing',
         description='Smooths weights in the area where weights got inpainted',
+        default=False)
+    isolate_loose_parts: bpy.props.BoolProperty(
+        name='Isolate Loose Parts',
+        description='Inpaint each connected mesh island independently so weights cannot bleed between disconnected parts that happen to be close in space (e.g. left and right sock). Mainly affects Point inpaint mode',
         default=False)
     smooth_limit_debug: bpy.props.BoolProperty(
         name='Limited vertices to Vertex Group',
@@ -549,6 +559,7 @@ class SettingsPanel(bpy.types.Panel):
         settings = context.scene.robust_weight_transfer_settings
         layout.operator('object.rbt_reset_scene_settings', icon='LOOP_BACK', text='Reset to Defaults')
         layout.prop(settings, 'inpaint_mode')
+        layout.prop(settings, 'isolate_loose_parts')
         layout.prop(settings, 'draw_matched')
         row = layout.row()
         row.enabled = not settings.enforce_four_bone_limit

--- a/weighttransfer.py
+++ b/weighttransfer.py
@@ -164,6 +164,60 @@ def find_matches_closest_surface(source_verts, source_triangles, source_normals,
     return Matched, W2
 
 
+def connected_components_split(F, num_verts):
+    """
+    Split a mesh into connected components (islands) by topology.
+
+    Returns a list of (vert_indices, local_F) tuples where vert_indices maps
+    island-local vertices back to the original mesh, and local_F is the island's
+    triangle list re-indexed to [0, len(vert_indices)).
+
+    Vertices unreferenced by F are grouped into their own singleton islands so
+    callers can still carry their data through.
+    """
+    num_conn, conn, _ = igl.connected_components(igl.adjacency_matrix(F))
+    referenced = np.zeros(num_verts, dtype=bool)
+    referenced[F.reshape(-1)] = True
+    islands = []
+    for i in range(num_conn):
+        vidx = np.where(conn == i)[0]
+        if len(vidx) == 0:
+            continue
+        vmap = -np.ones(num_verts, dtype=np.int64)
+        vmap[vidx] = np.arange(len(vidx))
+        tri_mask = np.all(vmap[F] >= 0, axis=1)
+        local_F = vmap[F[tri_mask]].astype(F.dtype)
+        islands.append((vidx, local_F))
+    unreferenced = np.where(~referenced)[0]
+    for v in unreferenced:
+        islands.append((np.array([v], dtype=np.int64), np.zeros((0, 3), dtype=F.dtype)))
+    return islands
+
+
+def inpaint_per_island(V2, F2, W2, Matched, point_cloud):
+    """
+    Run `inpaint` independently on each topological island of (V2, F2) so
+    weights cannot bleed between disconnected parts (e.g. left/right sock).
+    Islands with zero matched vertices are left as-is. Returns (result, W)
+    matching the `inpaint` signature; result is False if every island failed
+    or none had any matches.
+    """
+    W_out = W2.astype(np.float32).copy()
+    any_success = False
+    for vidx, local_F in connected_components_split(F2, V2.shape[0]):
+        local_matched = Matched[vidx]
+        if not np.any(local_matched):
+            continue
+        local_V = V2[vidx]
+        local_W = W2[vidx]
+        result, local_out = inpaint(local_V, local_F, local_W, local_matched, point_cloud)
+        if not result:
+            return False, W_out
+        W_out[vidx] = local_out
+        any_success = True
+    return any_success, W_out
+
+
 def inpaint(V2, F2, W2, Matched, point_cloud):
     """
     Inpaint weights for all the vertices on the target mesh for which  we didnt 


### PR DESCRIPTION
Add Isolate Loose Parts toggle to prevent weight bleed between mesh islands

When transferring or inpainting weights on a target with multiple disconnected islands (e.g. left and right sock in one mesh), the Point inpaint mode could bleed weights across islands via proximity-based Laplacian connections. The new toggle runs the solve independently per connected component so disconnected parts stay isolated.